### PR TITLE
fix 'devtoosl' typo in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -58,5 +58,5 @@ RStudio](https://dailies.rstudio.com/) and development versions of the
 
 ```r
 devtools::install_github("rstudio/rstudioapi")
-devtoosl::install_github("gaborcsardi/crayon")
+devtools::install_github("gaborcsardi/crayon")
 ```

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ In order to have color in the RStudio terminal you need a [daily build of RStudi
 
 ``` r
 devtools::install_github("rstudio/rstudioapi")
-devtoosl::install_github("gaborcsardi/crayon")
+devtools::install_github("gaborcsardi/crayon")
 ```


### PR DESCRIPTION
Hey guys, good work! I found a little typo in your README (`devtoosl::` -> `devtools::`).