### PR TITLE
correct GitHub username of R package 'boxes'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Suggests:
   BiocInstaller,
   testthat
 Remotes: 
-  r-pkgs/boxes
+  r-lib/boxes


### PR DESCRIPTION
Error message when installing: "package ‘boxes’ is not available". I had to do some digging to find that it is on GitHub, under 'r-lib' (not 'r-pkgs' as pointed to in the *Remotes* section of the DESCRIPTION file)