### PR TITLE
substitute title for path in suggest when path not given

### DIFF
--- a/R/available.R
+++ b/R/available.R
@@ -65,7 +65,11 @@ create <- function(name, ...) {
 #' @export
 suggest <- function(path = ".", title = NULL) {
   if (is.null(title)) {
-    title <- unname(desc::desc(path)$get("Title"))
+    if (file.exists (path)) {
+      title <- unname(desc::desc(path)$get("Title"))
+    } else {
+      title <- path
+    }
     if (is.na(title)) {
       stop("No title found, please specify one with `title`.", call. = FALSE)
     }

--- a/R/available.R
+++ b/R/available.R
@@ -66,7 +66,9 @@ create <- function(name, ...) {
 suggest <- function(path = ".", title = NULL) {
   if (is.null(title)) {
     if (file.exists (path)) {
-      title <- unname(desc::desc(path)$get("Title"))
+      title <- tryCatch (
+                         unname(desc::desc(path)$get("Title")),
+                         error = function (e) NA)
     } else {
       title <- path
     }


### PR DESCRIPTION
Motivation: It's better to presume that people are **not** going to remember or be bothered to look up argument names. Without this PR:
```
> suggest("some stuff")
Error: File does not exist
```
Oh yeah, I have to read the docs to find the reason for that seemingly uninformative error message:
```
suggest(title = "some stuff") # gee, that was a bit annoying!
[1] "stuff"
```
With this PR:
```
> suggest("some stuff")
[1] "stuff"
```
hey, that's easier!