### PR TITLE
Add better option to suppress browser

### DIFF
--- a/R/available.R
+++ b/R/available.R
@@ -6,10 +6,14 @@
 #' - Positive or negative sentiment
 #' - Urban Dictionary
 #' @param name Name of package to search
+#' @param browse Whether browser should be opened for all web links,
+#'        default = TRUE. Default can be changed by setting
+#'        \code{available.browse} in \code{.Rprofile}. See \link[base]{Startup}
+#'        for more details.
 #' @param ... Additional arguments passed to [utils::available.packages()].
 #' @importFrom memoise memoise
 #' @export
-available <- function(name, ...) {
+available <- function(name, browse = getOption("available.browse", TRUE), ...) {
   res <- list(valid_package_name(name),
     available_on_cran(name, ...),
     available_on_bioc(name, ...),
@@ -27,11 +31,17 @@ available <- function(name, ...) {
           get_urban_data(term),
           sentiment(term))
           })))
-    structure(res, class = "available_query", packagename = name)
+  structure(res, class = "available_query", packagename = name,
+            browse = browse)
 }
 
 #' @export
 print.available_query <- function(x, ...) {
+  if (!attr(x, "browse")) {
+    base_browser <- getOption("browser")
+    options(browser = "false")
+    on.exit(options(browser = base_browser))
+  }
   cat(boxes::rule(attr(x, "packagename")), "\n", sep = "")
   for (i in x) {
     print(i)

--- a/man/available.Rd
+++ b/man/available.Rd
@@ -4,10 +4,15 @@
 \alias{available}
 \title{See if a name is available}
 \usage{
-available(name, ...)
+available(name, browse = getOption("available.browse", TRUE), ...)
 }
 \arguments{
 \item{name}{Name of package to search}
+
+\item{browse}{Whether browser should be opened for all web links,
+default = TRUE. Default can be changed by setting
+\code{available.browse} in \code{.Rprofile}. See \link[base]{Startup}
+for more details.}
 
 \item{...}{Additional arguments passed to [utils::available.packages()].}
 }


### PR DESCRIPTION
Added optional parameter to prevent URLs from being opened in browser using API based on feedback in pull request #28. Solves issue #24 by calling print with options(browser = "false") when user doesn't want URLs to open.