### PR TITLE
Fix spelling in package installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ knitr::opts_chunk$set(
 You can install available from CRAN with:
 
 ```{r CRAN-installation, eval = FALSE}
-install.packages("availabe")
+install.packages("available")
 ```
 
 Or the development version from GitHub with:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 You can install available from CRAN with:
 
 ``` r
-install.packages("availabe")
+install.packages("available")
 ```
 
 Or the development version from GitHub with:


### PR DESCRIPTION
Fixes a typo in the CRAN installation instructions whereby the package name is given as "availabe"