### PR TITLE
Use BiocManager preferentially

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # available (development version)
 
+* `BiocManager` is now preferred to `BiocInstaller` if both are installed (#44, @luciorq).
+
 * `create()` now uses `usethis::create_package()` rather than the deprecated `devtools::create()`.
 
 # available 1.0.2

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -2,10 +2,10 @@
 #' @export
 available_on_bioc <- function(name, repos = NULL, ...) {
   if (is.null(repos)) {
-    if (requireNamespace("BiocInstaller", quietly = TRUE)) {
-      repos <- BiocInstaller::biocinstallRepos()
-    } else if (requireNamespace("BiocManager", quietly = TRUE)) {
+    if (requireNamespace("BiocManager", quietly = TRUE)) {
       repos <- BiocManager::repositories()
+    } else if (requireNamespace("BiocInstaller", quietly = TRUE)) {
+      repos <- BiocInstaller::biocinstallRepos()
     } else {
       # Search on latest bioc release
       repos <- c(


### PR DESCRIPTION
BiocManager should be used preferentially instead of BiocInstaller to avoid deprecated warning.
This Pull request is related to the Issue #44 