### PR TITLE
Removing multiple checks if Urban Dictionary must be used

### DIFF
--- a/R/available.R
+++ b/R/available.R
@@ -113,35 +113,20 @@ suggest <- function(path = ".",  field = c("Title", "Description"), text = NULL)
 
 
 check_online_terms <- function(term, urban = TRUE) {
-  if (urban) {
-    compact(list(
-      get_bad_words(term),
+      compact(list(get_bad_words(term),
       get_abbreviation(term),
       get_wikipidia(term),
       get_wiktionary(term),
-      get_urban_data(term),
+      if (urban) get_urban_data(term),
       get_sentiment(term)))
-  } else {
-    compact(list(
-      get_bad_words(term),
-      get_abbreviation(term),
-      get_wikipidia(term),
-      get_wiktionary(term),
-      get_sentiment(term)))
-  }
 }
 
 
 check_urban <- function() {
-  if (interactive()) {
+  if (!interactive()) {
+    return(TRUE)
+  }
     cat("Urban Dictionary can contain potentially offensive results,\n  should they be included? [Y]es / [N]o:\n")
     result <- tryCatch(scan("", what = "character", quiet = TRUE, nlines = 1), error = function(x) "N")
-    if (!identical(toupper(result), "Y")) {
-      TRUE
-    } else {
-      FALSE
-    }
-  } else {
-    TRUE
-  }
+    identical(toupper(result), "Y")
 }

--- a/R/available.R
+++ b/R/available.R
@@ -31,18 +31,13 @@ available <- function(name, browse = getOption("available.browse", TRUE), ...) {
     available_on_bioc(name, ...),
     available_on_github(name))
   terms <- name_to_search_terms(name)
+
+  urban_dictonary <- check_urban()
+
   res <- c(res,
     unlist(recursive = FALSE,
-      lapply(terms,
-      function(term) {
-        compact(list(
-          get_bad_words(term),
-          get_abbreviation(term),
-          get_wikipidia(term),
-          get_wiktionary(term),
-          get_urban_data(term),
-          get_sentiment(term)))
-          })))
+      lapply(terms, check_online_terms, urban = urban_dictonary
+      )))
   structure(res, class = "available_query", packagename = name,
             browse = browse)
 }
@@ -113,4 +108,40 @@ suggest <- function(path = ".",  field = c("Title", "Description"), text = NULL)
   }
 
   namr(text)
+}
+
+
+
+check_online_terms <- function(term, urban = TRUE) {
+  if (urban) {
+    compact(list(
+      get_bad_words(term),
+      get_abbreviation(term),
+      get_wikipidia(term),
+      get_wiktionary(term),
+      get_urban_data(term),
+      get_sentiment(term)))
+  } else {
+    compact(list(
+      get_bad_words(term),
+      get_abbreviation(term),
+      get_wikipidia(term),
+      get_wiktionary(term),
+      get_sentiment(term)))
+  }
+}
+
+
+check_urban <- function() {
+  if (interactive()) {
+    cat("Urban Dictionary can contain potentially offensive results,\n  should they be included? [Y]es / [N]o:\n")
+    result <- tryCatch(scan("", what = "character", quiet = TRUE, nlines = 1), error = function(x) "N")
+    if (!identical(toupper(result), "Y")) {
+      TRUE
+    } else {
+      FALSE
+    }
+  } else {
+    TRUE
+  }
 }

--- a/R/get_urban_data.R
+++ b/R/get_urban_data.R
@@ -1,15 +1,9 @@
 #' get urban dictionary definitions and tags
 #'
 #' @param name Name of package to search
+#' @note Urban Dictionary can contain potentially offensive results
 #' @export
-get_urban_data<- function(name) {
-  if (interactive()) {
-    cat("Urban Dictionary can contain potentially offensive results,\n  should they be included? [Y]es / [N]o:\n")
-    result <- tryCatch(scan("", what = "character", quiet = TRUE, nlines = 1), error = function(x) "N")
-    if (!identical(toupper(result), "Y")) {
-      return(NULL)
-    }
-  }
+get_urban_data <- function(name) {
   term <- tryCatch(as.data.frame(udapi::get_term(name)),
                    error = function(e) e)
   tags <- tryCatch(udapi::get_tags(name)$tags, error = function(e) e)

--- a/man/get_urban_data.Rd
+++ b/man/get_urban_data.Rd
@@ -12,3 +12,6 @@ get_urban_data(name)
 \description{
 get urban dictionary definitions and tags
 }
+\note{
+Urban Dictionary can contain potentially offensive results
+}

--- a/tests/testthat/test-check_urban.R
+++ b/tests/testthat/test-check_urban.R
@@ -1,0 +1,3 @@
+test_that("check_urban works", {
+  expect_true(check_urban())
+})


### PR DESCRIPTION
This pull request is related to #49: I moved the check to a new function (and removed it from the `get_urban_data` but introduced a note in the documentation).

Moved the function to retrieve the data from online sources to its own function, with an argument to know if Urban Dictionary must be checked. 